### PR TITLE
Bug/instruction image url

### DIFF
--- a/MWCameraPlugin.podspec
+++ b/MWCameraPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWCameraPlugin'
-    s.version               = '0.0.18'
+    s.version               = '0.0.19'
     s.summary               = 'Camera plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Camera plugin for MobileWorkflow on iOS, containg camera capture related steps:

--- a/MWCameraPlugin/MWCameraPlugin/Video Capture Step/Video Capture Modal Step/MWVideoCaptureModalStep.swift
+++ b/MWCameraPlugin/MWCameraPlugin/Video Capture Step/Video Capture Modal Step/MWVideoCaptureModalStep.swift
@@ -64,7 +64,7 @@ extension MWVideoCaptureModalStep: BuildableStep {
                                   deviceCamera: stepInfo.data.content["deviceCamera"] as? String,
                                   videoOrientation: stepInfo.data.content["videoOrientation"] as? String,
                                   instructionsText: stepInfo.data.content["instructionsText"] as? String,
-                                  imageURL: stepInfo.data.content["instructionsImageURL"] as? String,
+                                  imageURL: stepInfo.data.content["imageURL"] as? String,
                                   session: stepInfo.session,
                                   services: services,
                                   theme: stepInfo.context.theme)


### PR DESCRIPTION
This is to fix [comment 4](https://futureworkshops.atlassian.net/browse/MW-1685?focusedCommentId=42048) by Oliver. 

This issue is that the backend seems to resolve unsplash images URLs by adding the resolution at the end only if they are named "imageURL", mine was named "instructionsImageURL".

[MW-1685]

**Steps to test:**

* Test that unsplash images work in Camera / Video Capture Landscape step. Use [this](https://unsplash.com/photos/IahKTlr7c7I) image for example and it should display 

**Expected result:**

Image should display in the step just like for instruction steps


[MW-1685]: https://futureworkshops.atlassian.net/browse/MW-1685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ