### PR TITLE
Task/image capture step

### DIFF
--- a/MWCameraPlugin.podspec
+++ b/MWCameraPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWCameraPlugin'
-    s.version               = '0.0.21'
+    s.version               = '0.0.22'
     s.summary               = 'Camera plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Camera plugin for MobileWorkflow on iOS, containg camera capture related steps:

--- a/MWCameraPlugin/MWCameraPlugin/Image Capture Step/MWImageCaptureCameraPreviewView.swift
+++ b/MWCameraPlugin/MWCameraPlugin/Image Capture Step/MWImageCaptureCameraPreviewView.swift
@@ -1,0 +1,216 @@
+//
+//  MWImageCaptureCameraPreviewView.swift
+//  MobileWorkflowCore
+//
+//  Created by Julien Hebert on 07/12/2021.
+//
+
+import UIKit
+import MobileWorkflowCore
+import AVFAudio
+
+fileprivate let PreviewImagePadding: CGFloat = 20.0
+
+final class MWImageCaptureCameraPreviewView : UIView {
+    
+    var templateImageInsets : UIEdgeInsets = UIEdgeInsets(top: 0.1, left: 0.1, bottom: 0.1, right: 0.1)
+    
+    private lazy var previewLayer = AVCaptureVideoPreviewLayer()
+    private lazy var templateImageView = UIImageView()
+    private var templateImageViewTopInsetConstraint : NSLayoutConstraint!
+    private var templateImageViewLeftInsetConstraint : NSLayoutConstraint!
+    private var templateImageViewBottomInsetConstraint : NSLayoutConstraint!
+    private var templateImageViewRightInseConstraint : NSLayoutConstraint!
+    private lazy var capturedImageView = UIImageView()
+    
+    override init(frame: CGRect) {
+        
+        super.init(frame: frame)
+        
+        self.previewLayer.videoGravity = .resizeAspectFill
+        self.previewLayer.needsDisplayOnBoundsChange = true
+        self.layer.addSublayer(self.previewLayer)
+
+        self.capturedImageView.contentMode = .scaleAspectFit
+        self.addSubview(self.capturedImageView)
+
+        self.templateImageView.contentMode = .scaleAspectFit
+        self.templateImageView.isHidden = true
+        self.addSubview(self.templateImageView)
+
+        self.translatesAutoresizingMaskIntoConstraints = false
+        self.templateImageView.translatesAutoresizingMaskIntoConstraints = false
+        self.capturedImageView.translatesAutoresizingMaskIntoConstraints = false
+        self.setUpConstraints()
+        
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setUpConstraints(){
+        var constraints : [NSLayoutConstraint] = []
+        
+        self.templateImageView.setContentHuggingPriority(UILayoutPriority(0), for: .horizontal)
+        self.templateImageView.setContentHuggingPriority(UILayoutPriority(0), for: .vertical)
+        self.templateImageView.setContentCompressionResistancePriority(UILayoutPriority(0), for: .horizontal)
+        self.templateImageView.setContentCompressionResistancePriority(UILayoutPriority(0), for: .vertical)
+        self.capturedImageView.setContentHuggingPriority(UILayoutPriority(0), for: .horizontal)
+        self.capturedImageView.setContentHuggingPriority(UILayoutPriority(0), for: .vertical)
+        self.capturedImageView.setContentCompressionResistancePriority(UILayoutPriority(0), for: .horizontal)
+        self.capturedImageView.setContentCompressionResistancePriority(UILayoutPriority(0), for: .vertical)
+
+        self.templateImageViewTopInsetConstraint = NSLayoutConstraint(item: self.templateImageView, attribute: .top, relatedBy: .equal, toItem: self, attribute: .top, multiplier: 1.0, constant: 0.0)
+
+        self.templateImageViewLeftInsetConstraint = NSLayoutConstraint(item: self.templateImageView, attribute: .left, relatedBy: .equal, toItem: self, attribute: .left, multiplier: 1.0, constant: 0.0)
+
+        self.templateImageViewBottomInsetConstraint = NSLayoutConstraint(item: self.templateImageView, attribute: .bottom, relatedBy: .equal, toItem: self, attribute: .bottom, multiplier: 1.0, constant: 0.0)
+
+        self.templateImageViewRightInseConstraint = NSLayoutConstraint(item: self.templateImageView, attribute: .right, relatedBy: .equal, toItem: self, attribute: .right, multiplier: 1.0, constant: 0.0)
+        
+        constraints.append(contentsOf: [self.templateImageViewTopInsetConstraint,
+                                        self.templateImageViewLeftInsetConstraint,
+                                        self.templateImageViewBottomInsetConstraint,
+                                        self.templateImageViewRightInseConstraint])
+        
+        constraints.append(contentsOf: [NSLayoutConstraint(item: self.capturedImageView,
+                                                           attribute: .top,
+                                                           relatedBy: .equal,
+                                                           toItem: self,
+                                                           attribute: .top,
+                                                           multiplier: 1.0,
+                                                           constant: PreviewImagePadding),
+                                        NSLayoutConstraint(item: self.capturedImageView,
+                                                           attribute: .leading,
+                                                           relatedBy: .equal,
+                                                           toItem: self,
+                                                           attribute: .leading,
+                                                           multiplier: 1.0,
+                                                           constant: PreviewImagePadding),
+                                        NSLayoutConstraint(item: self.capturedImageView,
+                                                           attribute: .trailing,
+                                                           relatedBy: .equal,
+                                                           toItem: self,
+                                                           attribute: .trailing,
+                                                           multiplier: 1.0,
+                                                           constant: -PreviewImagePadding),
+                                        NSLayoutConstraint(item: self.capturedImageView,
+                                                           attribute: .bottom,
+                                                           relatedBy: .equal,
+                                                           toItem: self,
+                                                           attribute: .bottom,
+                                                           multiplier: 1.0,
+                                                           constant: -PreviewImagePadding)])
+        
+        NSLayoutConstraint.activate(constraints)
+        
+    }
+    
+    var session : AVCaptureSession? {
+        get{
+            return self.previewLayer.session
+        }
+        set {
+            self.previewLayer.session = newValue
+        }
+    }
+    
+    var templateImage : UIImage? {
+        get{
+            return self.templateImageView.image
+        }
+        set {
+            self.templateImageView.image = newValue?.withRenderingMode(.alwaysTemplate)
+        }
+    }
+    
+    var isTemplateImageHidden : Bool {
+        get{
+            return self.templateImageView.isHidden
+        }
+        set {
+            self.templateImageView.isHidden = newValue
+        }
+    }
+    
+    var capturedImage : UIImage? {
+        get{
+            return self.capturedImageView.image
+        }
+        set {
+            self.capturedImageView.image = newValue
+            self.previewLayer.isHidden = newValue != nil
+        }
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        self.previewLayer.frame = self.frame
+        
+        self.updateInsets()
+    }
+    
+    private func updateInsets(){
+        let previewLayerContentFrameInsets = self.getPreviewLayerContentFrameInsets()
+        if (!UIEdgeInsetsEqualToEdgeInsets(previewLayerContentFrameInsets, self.layoutMargins)) {
+            self.layoutMargins = previewLayerContentFrameInsets
+        }
+        
+        // Update the insets on the template image view, if needed
+        let previewLayerContentFrame = self.previewLayer.frame.inset(by: previewLayerContentFrameInsets)
+        
+        let insets = UIEdgeInsets(top: round(self.templateImageInsets.top * previewLayerContentFrame.size.height),
+                                  left: round(self.templateImageInsets.left * previewLayerContentFrame.size.width),
+                                  bottom: round(self.templateImageInsets.bottom * previewLayerContentFrame.size.height),
+                                  right: round(self.templateImageInsets.right * previewLayerContentFrame.size.width))
+    
+        if (self.templateImageViewTopInsetConstraint.constant != insets.top) {
+            self.templateImageViewTopInsetConstraint.constant = insets.top
+        }
+        if (self.templateImageViewLeftInsetConstraint.constant != insets.left) {
+            self.templateImageViewLeftInsetConstraint.constant = insets.left
+        }
+        if (self.templateImageViewBottomInsetConstraint.constant != -insets.bottom) {
+            self.templateImageViewBottomInsetConstraint.constant = -insets.bottom
+        }
+        if (self.templateImageViewRightInseConstraint.constant != -insets.right) {
+            self.templateImageViewRightInseConstraint.constant = -insets.right
+        }
+        
+    }
+    
+    private func getPreviewLayerContentFrameInsets() -> UIEdgeInsets {
+
+        guard let inputs = self.previewLayer.session?.inputs, let input = inputs.first as? AVCaptureDeviceInput else {return .zero}
+                
+        let videoDimensions = CMVideoFormatDescriptionGetDimensions(input.device.activeFormat.formatDescription)
+        let orientation = self.previewLayer.connection?.videoOrientation
+        let landscape = (orientation == .landscapeLeft || orientation == .landscapeRight)
+        
+        let size = CGSize(width: CGFloat(landscape ? videoDimensions.width : videoDimensions.height),
+                          height: CGFloat(landscape ? videoDimensions.height : videoDimensions.width))
+        
+        let contentFrame = AVMakeRect(aspectRatio: size, insideRect: self.previewLayer.frame)
+        let overallFrame = self.previewLayer.frame
+        
+        return UIEdgeInsets(top: contentFrame.origin.y - overallFrame.origin.y,
+                            left: contentFrame.origin.x - overallFrame.origin.x,
+                            bottom: (overallFrame.origin.y + overallFrame.size.height) - (contentFrame.origin.y + contentFrame.size.height),
+                            right: (overallFrame.origin.x + overallFrame.size.width) - (contentFrame.origin.x + contentFrame.size.width))
+        
+    }
+    
+    var videoOrientation : AVCaptureVideoOrientation? {
+        get{
+            return self.previewLayer.connection?.videoOrientation
+        }
+        set {
+            guard let videoOrientation = newValue else {return}
+            self.previewLayer.connection?.videoOrientation = videoOrientation
+        }
+    }
+    
+}
+

--- a/MWCameraPlugin/MWCameraPlugin/Image Capture Step/MWImageCaptureError.swift
+++ b/MWCameraPlugin/MWCameraPlugin/Image Capture Step/MWImageCaptureError.swift
@@ -1,0 +1,38 @@
+//
+//  MWImageCaptureError.swift
+//  MWCameraPlugin
+//
+//  Created by Julien Hebert on 14/12/2021.
+//
+
+import Foundation
+
+enum ImageCaptureError: LocalizedError {
+    case captureErrorCameraNotFound
+    case captureErrorNoPermission
+    case cameraUnavailable
+    case noOutputDirectory
+    case cannotWriteFile
+    case photoLibraryNotAvailable
+    
+    var errorDescription: String? {
+        switch self {
+        case .captureErrorCameraNotFound:
+            return L10n.ImageCaptureStep.captureErrorCameraNotFound
+        case .captureErrorNoPermission:
+            return L10n.ImageCaptureStep.captureErrorNoPermissions
+        case .cameraUnavailable:
+            return L10n.ImageCaptureStep.cameraUnavailable
+        case .noOutputDirectory:
+            return L10n.ImageCaptureStep.captureErrorNoOutputDirectory
+        case .cannotWriteFile:
+            return L10n.ImageCaptureStep.captureErrorCannotWriteFile
+        case .photoLibraryNotAvailable:
+            return L10n.ImageCaptureStep.photoLibraryNotAvailable
+        }
+    }
+    
+    var localizedDescription: String {
+        return self.errorDescription ?? ""
+    }
+}

--- a/MWCameraPlugin/MWCameraPlugin/Image Capture Step/MWImageCaptureStep.swift
+++ b/MWCameraPlugin/MWCameraPlugin/Image Capture Step/MWImageCaptureStep.swift
@@ -1,0 +1,74 @@
+//
+//  MWImageCaptureStep.swift
+//  MobileWorkflowCore
+//
+//  Created by Julien Hebert on 07/12/2021.
+//
+
+import UIKit
+import MobileWorkflowCore
+import AVFoundation
+
+final class MWImageCaptureStep: MWStep {
+    
+    public var imageURL: String?
+    public let session: Session
+    public let services: StepServices
+    
+    let devicePosition: AVCaptureDevice.Position
+    let compressionQuality: CGFloat
+    let showGalleryOption: Bool
+    let captureRaw: Bool = false
+    
+    init(identifier: String,
+         imageURL: String?,
+         devicePosition: String?,
+         compressionQuality: CGFloat?,
+         showGalleryOption: Bool?,
+         session: Session,
+         services: StepServices,
+         theme: Theme) {
+        self.imageURL = imageURL
+        self.devicePosition = AVCaptureDevice.Position(stringValue: devicePosition)
+        self.compressionQuality = compressionQuality ?? 1.0
+        self.showGalleryOption = showGalleryOption ?? false
+        self.session = session
+        self.services = services
+        super.init(identifier: identifier, theme: theme)
+    }
+    
+    required init(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func instantiateViewController() -> StepViewController {
+        return MWImageCaptureViewController(step: self)
+    }
+}
+
+extension MWImageCaptureStep: BuildableStep {
+    static func build(stepInfo: StepInfo, services: StepServices) throws -> Step {
+        
+        return MWImageCaptureStep(identifier: stepInfo.data.identifier,
+                                  imageURL: stepInfo.data.content["imageURL"] as? String,
+                                  devicePosition: stepInfo.data.content["devicePosition"] as? String,
+                                  compressionQuality: stepInfo.data.content["imageQuality"] as? CGFloat,
+                                  showGalleryOption: stepInfo.data.content["showGalleryOption"] as? Bool,
+                                  session: stepInfo.session,
+                                  services: services,
+                                  theme: stepInfo.context.theme)
+  
+    }
+}
+
+extension AVCaptureDevice.Position {
+    
+    init(stringValue: String?){
+        if let stringValue = stringValue, let rawValue = Int(stringValue), let devicePosition = AVCaptureDevice.Position(rawValue: rawValue) {
+            self = devicePosition
+        }else{
+            self = .back
+        }
+    }
+    
+}

--- a/MWCameraPlugin/MWCameraPlugin/Image Capture Step/MWImageCaptureView.swift
+++ b/MWCameraPlugin/MWCameraPlugin/Image Capture Step/MWImageCaptureView.swift
@@ -1,0 +1,220 @@
+//
+//  MWImageCaptureView.swift
+//  MobileWorkflowCore
+//
+//  Created by Julien Hebert on 07/12/2021.
+//
+
+import UIKit
+import MobileWorkflowCore
+
+protocol MWImageCaptureViewDelegate : AnyObject {
+    func capturePressed(handler: ((Bool) -> Void)?)
+    func retakePressed(handler: (() -> Void)?)
+    func videoOrientationDidChange(videoOrientation: AVCaptureVideoOrientation)
+}
+
+final class MWImageCaptureView : UIView {
+    
+    weak var delegate: MWImageCaptureViewDelegate?
+    
+    private lazy var previewView = MWImageCaptureCameraPreviewView()
+
+    private var variableConstraints : [NSLayoutConstraint] = []
+    
+    var templateImage : UIImage? {
+        get{
+            return self.previewView.templateImage
+        }
+        set {
+            self.previewView.templateImage = newValue
+            self.updateAppearance()
+        }
+    }
+    
+    var error: Error? {
+        didSet{
+            self.updateAppearance()
+        }
+    }
+    
+    private var capturePressesIgnored : Bool = false
+    private var retakePressesIgnored : Bool = false
+    private var showSkipButtonItem : Bool = false
+    
+    let imageCaptureStep : MWImageCaptureStep
+    
+    init(imageCaptureStep : MWImageCaptureStep, frame: CGRect) {
+        
+        self.imageCaptureStep = imageCaptureStep
+        
+        self.showSkipButtonItem = imageCaptureStep.isOptional ?? false
+        
+        super.init(frame: frame)
+        
+        self.addSubview(self.previewView)
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(self.orientationDidChange), name: UIApplication.didChangeStatusBarOrientationNotification, object: nil)
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(self.queue_sessionRunning), name: UIApplication.didChangeStatusBarOrientationNotification, object: nil)
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(self.sessionWasInterrupted(notification:)), name: NSNotification.Name.AVCaptureSessionWasInterrupted, object: nil)
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(self.sessionInterruptionEnded(notification:)), name: NSNotification.Name.AVCaptureSessionInterruptionEnded, object: nil)
+        
+        self.updateAppearance()
+        
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    @IBAction func capturePressed(){
+        // If we are still waiting for the delegate to complete, ignore futher presses
+        if self.capturePressesIgnored { return }
+
+        // Ignore futher presses until the delegate completes
+        self.capturePressesIgnored = true
+
+        // Capture the image via the delegate
+        self.delegate?.capturePressed(handler: { [weak self] _ in
+            self?.capturePressesIgnored = false
+        })
+        
+    }
+    
+    @IBAction func retakePressed(){
+        
+        // If we are still waiting for the delegate to complete, ignore futher presses
+        if self.retakePressesIgnored { return }
+
+        // Ignore futher presses until the delegate completes
+        self.retakePressesIgnored = true
+
+        // Tell the delegate to start capturing again
+        self.delegate?.retakePressed(handler: { [weak self] in
+            self?.retakePressesIgnored = false
+        })
+    
+    }
+    
+    @IBAction func orientationDidChange(){
+        DispatchQueue.main.async {
+            guard let interfaceOrientation = self.window?.windowScene?.interfaceOrientation else {return}
+            var orientation : AVCaptureVideoOrientation = .portrait
+            switch interfaceOrientation {
+            case .landscapeRight:
+                orientation = .landscapeRight
+            case .landscapeLeft:
+                orientation = .landscapeLeft
+            case .portraitUpsideDown:
+                orientation = .portraitUpsideDown
+            case .portrait:
+                orientation = .portrait
+            case .unknown:
+                return
+            }
+
+            self.previewView.videoOrientation = orientation
+            self.delegate?.videoOrientationDidChange(videoOrientation: orientation)
+            self.setNeedsUpdateConstraints()
+        }
+    }
+    
+    @IBAction func queue_sessionRunning(){
+        DispatchQueue.main.async {
+            self.updateAppearance()
+        }
+    }
+    
+    private func updateAppearance(){
+        self.previewView.alpha = self.error != nil ? 0 : 1
+
+        if let error = self.error {
+            self.previewView.isTemplateImageHidden = true
+        } else if let capturedImage = self.capturedImage {
+            self.previewView.isTemplateImageHidden = true
+        } else {
+            self.previewView.isTemplateImageHidden = false
+        }
+    }
+    
+    var capturedImage: UIImage? {
+        get {
+            return self.previewView.capturedImage
+        }
+        set {
+            self.previewView.capturedImage = newValue
+            self.updateAppearance()
+        }
+    }
+    
+    override func updateConstraints() {
+        
+        NSLayoutConstraint.deactivate(self.variableConstraints)
+        self.variableConstraints.removeAll()
+
+        let views : [String: UIView] = ["view" : self, "previewView": previewView]
+        
+        self.previewView.translatesAutoresizingMaskIntoConstraints = false
+        
+        self.variableConstraints = [NSLayoutConstraint(item: self.previewView,
+                                                       attribute: .top,
+                                                       relatedBy: .equal,
+                                                       toItem: self,
+                                                       attribute: .top,
+                                                       multiplier: 1.0,
+                                                       constant: 0),
+                                    NSLayoutConstraint(item: self.previewView,
+                                                       attribute: .left,
+                                                       relatedBy: .equal,
+                                                       toItem: self,
+                                                       attribute: .left,
+                                                       multiplier: 1.0,
+                                                       constant: 0),
+                                    NSLayoutConstraint(item: self.previewView,
+                                                       attribute: .right,
+                                                       relatedBy: .equal,
+                                                       toItem: self,
+                                                       attribute: .right,
+                                                       multiplier: 1.0,
+                                                       constant: 0),
+                                    NSLayoutConstraint(item: self.previewView,
+                                                       attribute: .bottom,
+                                                       relatedBy: .equal,
+                                                       toItem: self,
+                                                       attribute: .bottom,
+                                                       multiplier: 1.0,
+                                                       constant: 0)]
+        
+        NSLayoutConstraint.activate(self.variableConstraints)
+        super.updateConstraints()
+    }
+    
+    var session: AVCaptureSession? {
+        get {
+            return self.previewView.session
+        }
+        set {
+            self.previewView.session = newValue
+            self.orientationDidChange()
+        }
+    }
+    
+    @IBAction func sessionWasInterrupted(notification: Notification){
+        guard let reason = notification.userInfo?[AVCaptureSessionInterruptionReasonKey] as? AVCaptureSession.InterruptionReason else {return}
+        if reason == AVCaptureSession.InterruptionReason.videoDeviceNotAvailableWithMultipleForegroundApps {
+            self.error = ImageCaptureError.cameraUnavailable
+        }
+    }
+    
+    @IBAction func sessionInterruptionEnded(notification: Notification){
+        self.error = nil
+    }
+    
+}

--- a/MWCameraPlugin/MWCameraPlugin/Image Capture Step/MWImageCaptureViewController.swift
+++ b/MWCameraPlugin/MWCameraPlugin/Image Capture Step/MWImageCaptureViewController.swift
@@ -1,0 +1,475 @@
+//
+//  MWImageCaptureViewController.swift
+//  MobileWorkflowCore
+//
+//  Created by Julien Hebert on 07/12/2021.
+//
+
+import UIKit
+import MobileWorkflowCore
+import AVFoundation
+import Combine
+
+final class MWImageCaptureViewController: MWContentStepViewController, UINavigationControllerDelegate {
+
+    private lazy var imageCaptureView : MWImageCaptureView = {
+        let imageCaptureView = MWImageCaptureView(imageCaptureStep: self.imageCaptureStep, frame: .zero)
+        imageCaptureView.delegate = self
+        imageCaptureView.translatesAutoresizingMaskIntoConstraints = false
+        return imageCaptureView
+    }()
+    
+    private lazy var sessionQueue = DispatchQueue(label: "session queue")
+    private var captureSession: AVCaptureSession?
+    private var photoOutput: AVCapturePhotoOutput?
+    private var templateImageLoad: AnyCancellable?
+    private var capturedImageData: Data? {
+        didSet{
+
+            self.imageCaptureView.capturedImage = self.capturedImageData != nil ? self.previewImage : nil
+            
+            // Remove the old file, if it exists, now that new data was acquired or reset
+            if let fileURL = self.fileURL {
+                try? FileManager.default.removeItem(at: fileURL)
+                self.fileURL = nil
+            }
+            
+            self.addResult()
+        
+        }
+    }
+    private var compressedImageData: Data?
+    private var rawImageData: Data?
+    private var fileURL: URL? {
+        didSet {
+            self.configureNavigationFooter()
+        }
+    }
+    private var previewImage: UIImage?
+    
+    private var captureRaw: Bool {
+        return self.imageCaptureStep.captureRaw
+    }
+    
+    private var imageDataExtension: String = "jpg"
+    
+    private lazy var imagePickerController: UIImagePickerController = {
+        let imagePickerController = UIImagePickerController()
+        imagePickerController.delegate = self
+        imagePickerController.allowsEditing = false
+        return imagePickerController
+    }()
+    
+    private var imageCaptureStep: MWImageCaptureStep {
+        return self.mwStep as! MWImageCaptureStep
+    }
+    
+    override init(step: Step) {
+        super.init(step: step)
+        
+        self.view.addSubview(self.imageCaptureView)
+        
+        if self.imageCaptureView.imageCaptureStep.showGalleryOption {
+            let iconImage = UIImage(systemName: "photo.on.rectangle")
+            self.utilityButtonItem = UIBarButtonItem(image: iconImage, style: .plain, target: self, action: #selector(self.imagePickerPressed))
+        }
+        
+        self.setUpConstraints()
+        
+    }
+    
+    public required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.configureNavigationFooter()
+
+        AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
+            DispatchQueue.main.async {
+                if granted == false {
+                    self?.handle(error: ImageCaptureError.captureErrorNoPermission)
+                }
+            }
+        }
+        
+        self.sessionQueue.async {
+            self.queue_SetupCaptureSession()
+        }
+        
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        self.sessionQueue.async {
+            self.captureSession?.startRunning()
+        }
+        
+        self.loadTemplateImage()
+        
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        
+        if self.captureSession?.isRunning == true {
+            self.sessionQueue.async {
+                self.captureSession?.stopRunning()
+            }
+        }
+        
+        self.templateImageLoad?.cancel()
+        
+        super.viewWillDisappear(animated)
+    }
+    
+    override func updateBarButtonItems() {
+        self.navigationItem.rightBarButtonItems = [self.cancelButtonItem, self.utilityButtonItem].compactMap {$0}
+    }
+    
+    private func configureNavigationFooter() {
+        
+        let skipButton = self.imageCaptureStep.isOptional ? ButtonConfig(isEnabled: true,
+                                                                         style: .textOnly,
+                                                                         title: L10n.ImageCaptureStep.skipButtonTitle,
+                                                                         action: self.goForward) : nil
+        
+        if self.fileURL != nil {
+            
+            self.navigationFooterConfig = NavigationFooterView.Config(
+                primaryButton: ButtonConfig(isEnabled: true, style: .primary, title: L10n.ImageCaptureStep.nextButtonTitle, action: self.goForward),
+                secondaryButton: ButtonConfig(isEnabled: true, style: .textOnly, title: L10n.ImageCaptureStep.recaptureImage, action: self.recaptureImage),
+                hasBlurredBackground: false
+            )
+        
+        } else {
+
+            self.navigationFooterConfig = NavigationFooterView.Config(
+                primaryButton: ButtonConfig(isEnabled: self.imageCaptureView.error == nil, style: .primary, title: L10n.ImageCaptureStep.captureImage, action: self.captureImage),
+                secondaryButton: skipButton,
+                hasBlurredBackground: false
+            )
+        }
+        
+        self.updateNavigationFooterView()
+        
+    }
+    
+    private func setUpConstraints(){
+        
+        NSLayoutConstraint.activate([NSLayoutConstraint(item: imageCaptureView,
+                                                        attribute: .top,
+                                                        relatedBy: .equal,
+                                                        toItem: self.contentView,
+                                                        attribute: .top,
+                                                        multiplier: 1.0,
+                                                        constant: 0),
+                                     NSLayoutConstraint(item: imageCaptureView,
+                                                        attribute: .left,
+                                                        relatedBy: .equal,
+                                                        toItem: self.contentView,
+                                                        attribute: .left,
+                                                        multiplier: 1.0,
+                                                        constant: 0),
+                                     NSLayoutConstraint(item: imageCaptureView,
+                                                        attribute: .right,
+                                                        relatedBy: .equal,
+                                                        toItem: self.contentView,
+                                                        attribute: .right,
+                                                        multiplier: 1.0,
+                                                        constant: 0),
+                                     NSLayoutConstraint(item: imageCaptureView,
+                                                        attribute: .bottom,
+                                                        relatedBy: .equal,
+                                                        toItem: self.contentView,
+                                                        attribute: .bottom,
+                                                        multiplier: 1.0,
+                                                        constant: 0)])
+
+    }
+    
+    private func loadTemplateImage(){
+        
+        guard let imageUrl = self.imageCaptureStep.imageURL, self.imageCaptureView.templateImage == nil else {return}
+        
+        self.templateImageLoad = self.imageCaptureStep.services.imageLoadingService.asyncLoad(image: imageUrl, session: self.imageCaptureStep.session) { [weak self] in
+            self?.imageCaptureView.templateImage = $0
+            self?.templateImageLoad = nil
+        }
+        
+    }
+    
+    private var imageFormat: [String : Any] {
+        let compression = [AVVideoQualityKey:self.imageCaptureView.imageCaptureStep.compressionQuality]
+        return [AVVideoCodecKey: AVVideoCodecType.jpeg,
+                AVVideoCompressionPropertiesKey: compression]
+    }
+    
+    private func createRawPhotoSettings(_ rawPixelFormatType: OSType) -> AVCapturePhotoSettings {
+
+        let photoSettings = AVCapturePhotoSettings(rawPixelFormatType: rawPixelFormatType, processedFormat: self.imageFormat)
+
+        photoSettings.flashMode = self.photoOutput?.supportedFlashModes.contains(.on) ?? false ? .auto : .off
+    
+        return photoSettings
+        
+    }
+    
+    private var generatePhotoSetting: AVCapturePhotoSettings {
+
+        let photoSettings = AVCapturePhotoSettings(format: self.imageFormat)
+
+        photoSettings.flashMode = self.photoOutput?.supportedFlashModes.contains(.on) ?? false ? .auto : .off
+    
+        return photoSettings
+        
+    }
+    
+    private func queue_SetupCaptureSession(){
+        
+        // Create the session
+        self.captureSession = AVCaptureSession()
+        
+        guard let captureSession = self.captureSession else { return }
+
+        captureSession.beginConfiguration()
+        captureSession.automaticallyConfiguresCaptureDeviceForWideColor = false
+        captureSession.sessionPreset = .photo
+        
+        // Get the camera
+        if let device = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: self.imageCaptureStep.devicePosition) {
+            
+            do {
+                let input = try AVCaptureDeviceInput(device: device)
+                let photoOutput = AVCapturePhotoOutput()
+                if captureSession.canAddInput(input) && captureSession.canAddOutput(photoOutput) {
+                    captureSession.addInput(input)
+                    captureSession.addOutput(photoOutput)
+                    self.photoOutput = photoOutput
+            
+                }else{
+                    DispatchQueue.main.async {
+                        self.handle(error: ImageCaptureError.captureErrorNoPermission)
+                    }
+                    self.captureSession = nil
+                }
+            }catch {
+                DispatchQueue.main.async {
+                    self.handle(error: error)
+                }
+                self.captureSession = nil
+            }
+            
+        }else{
+            DispatchQueue.main.async {
+                self.handle(error: ImageCaptureError.captureErrorCameraNotFound)
+            }
+            self.captureSession = nil
+        }
+        
+        captureSession.commitConfiguration()
+        self.imageCaptureView.session = captureSession
+        
+    }
+    
+    private func handle(error: Error) {
+        
+        // Shut down the session, if running
+        if self.captureSession?.isRunning == true {
+            self.sessionQueue.async {
+                self.captureSession?.stopRunning()
+            }
+        }
+        
+        // Reset the state to before the capture session was setup.  Order here is important
+        self.captureSession = nil
+        self.photoOutput = nil
+        self.imageCaptureView.session = nil
+        self.imageCaptureView.capturedImage = nil
+        self.capturedImageData = nil
+        self.fileURL = nil
+        
+        // Show the error in the image capture view
+        self.imageCaptureView.error = error
+        
+        self.show(error)
+    }
+    
+    private func writeCapturedDataWithError() throws -> URL? {
+        
+        guard let outputDirectory = self.outputDirectory else {
+            throw ImageCaptureError.noOutputDirectory
+        }
+        
+        let url = outputDirectory.appendingPathComponent(self.mwStep.identifier).appendingPathExtension(self.imageDataExtension)
+            
+        // If set properly, the outputDirectory is already created, so write the file into it
+        let fileManager = FileManager.default
+        
+        if fileManager.fileExists(atPath: url.path) {
+            do {
+                try fileManager.removeItem(atPath: url.path)
+            } catch {
+                throw ImageCaptureError.cannotWriteFile
+            }
+        }
+    
+
+        let created = fileManager.createFile(atPath: url.path, contents: self.capturedImageData, attributes: [FileAttributeKey.protectionKey : FileProtectionType.completeUnlessOpen])
+        if created == false {
+            throw ImageCaptureError.cannotWriteFile
+        }
+    
+        return url
+    }
+    
+    func addResult(){
+        
+        if self.fileURL == nil && self.capturedImageData != nil {
+            
+            do {
+                self.fileURL = try self.writeCapturedDataWithError()
+            }catch {
+                self.handle(error: error)
+            }
+            
+        }
+        
+        if let fileURL = self.fileURL {
+            let fileResult = FileResult(identifier: self.mwStep.identifier,
+                                        fileIdentifier: self.imageDataExtension,
+                                        fileURL: fileURL,
+                                        contentType: BinaryContentType.Image.jpeg)
+            fileResult.startDate = Date()
+            fileResult.endDate = Date()
+            self.addStepResult(fileResult)
+        }
+        
+    }
+    
+    func captureImage(){
+        self.imageCaptureView.capturePressed()
+    }
+    
+    func recaptureImage(){
+        self.imageCaptureView.retakePressed()
+    }
+    
+    @IBAction func imagePickerPressed() {
+        
+        if UIImagePickerController.isSourceTypeAvailable(.photoLibrary) {
+            self.present(self.imagePickerController, animated: true, completion: nil)
+        }else{
+            self.handle(error: ImageCaptureError.photoLibraryNotAvailable)
+        }
+        
+    }
+
+
+}
+
+extension MWImageCaptureViewController: MWImageCaptureViewDelegate {
+    
+    func capturePressed(handler: ((Bool) -> Void)?) {
+        
+        self.sessionQueue.async {
+            if self.captureRaw, let rawPixelFormatType = self.photoOutput?.availableRawPhotoFileTypes.first as? OSType {
+                self.photoOutput?.capturePhoto(with: self.createRawPhotoSettings(rawPixelFormatType), delegate: self)
+            }else{
+                self.photoOutput?.capturePhoto(with: self.generatePhotoSetting, delegate: self)
+            }
+            
+            DispatchQueue.main.async {
+                handler?(self.capturedImageData != nil)
+            }
+        }
+        
+    }
+    
+    func retakePressed(handler: (() -> Void)?) {
+        // Start the capture session, and reset the captured image to nil
+        
+        self.sessionQueue.async {
+            self.captureSession?.startRunning()
+            
+            DispatchQueue.main.async {
+                self.capturedImageData = nil
+                handler?()
+            }
+        }
+    }
+    
+    func videoOrientationDidChange(videoOrientation: AVCaptureVideoOrientation) {
+        
+        self.photoOutput?.connections.first?.videoOrientation = videoOrientation
+        
+    }
+    
+}
+
+extension MWImageCaptureViewController: AVCapturePhotoCaptureDelegate {
+    
+    func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
+        
+        guard let data = photo.fileDataRepresentation() else {return}
+        
+        if self.captureRaw {
+            if photo.isRawPhoto {
+                self.rawImageData = data
+            } else {
+                self.previewImage = UIImage(data: data)
+            }
+        } else {
+            self.compressedImageData = data
+            self.previewImage = UIImage(data: data)
+        }
+    }
+    
+    func photoOutput(_ output: AVCapturePhotoOutput, didFinishCaptureFor resolvedSettings: AVCaptureResolvedPhotoSettings, error: Error?) {
+        
+        if self.capturedImageData != nil {
+            self.captureSession?.stopRunning()
+        }
+        
+        DispatchQueue.main.async {
+            if self.captureRaw {
+                self.capturedImageData = self.rawImageData
+            }else{
+                self.capturedImageData = self.compressedImageData
+            }
+        }
+    
+    }
+}
+
+extension MWImageCaptureViewController: UIImagePickerControllerDelegate {
+    
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        
+        self.sessionQueue.async {
+            self.captureSession?.stopRunning()
+            
+            DispatchQueue.main.async {
+                guard let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage else {return}
+                self.previewImage = image
+                let imageData = image.jpegData(compressionQuality: 1.0)
+                self.capturedImageData = imageData
+                
+                self.dismiss(animated: true, completion: nil)
+            }
+        }
+        
+    }
+    
+}
+
+extension BinaryContentType {
+    
+    //getExtension is internal
+    fileprivate static func getExtension(type: String) -> String? {
+        return type.components(separatedBy: "/").last
+    }
+    
+}

--- a/MWCameraPlugin/MWCameraPlugin/L10n.swift
+++ b/MWCameraPlugin/MWCameraPlugin/L10n.swift
@@ -36,6 +36,18 @@ internal enum L10n {
         static let cancelTitle = L10n.localisedString(key: "videoCaptureStep.cancelTitle")
         static let nextButtonTitle = L10n.localisedString(key: "videoCaptureStep.nextButtonTitle")
         static let skipButtonTitle = L10n.localisedString(key: "videoCaptureStep.skipButtonTitle")
-        
+    }
+    
+    enum ImageCaptureStep {
+        static let captureImage = L10n.localisedString(key: "imageCaptureStep.captureImage")
+        static let recaptureImage = L10n.localisedString(key: "imageCaptureStep.recaptureImage")
+        static let nextButtonTitle = L10n.localisedString(key: "imageCaptureStep.nextButtonTitle")
+        static let skipButtonTitle = L10n.localisedString(key: "imageCaptureStep.skipButtonTitle")
+        static let cameraUnavailable = L10n.localisedString(key: "imageCaptureStep.cameraUnavailable")
+        static let captureErrorNoPermissions = L10n.localisedString(key: "imageCaptureStep.captureErrorNoPermissions")
+        static let captureErrorCameraNotFound = L10n.localisedString(key: "imageCaptureStep.captureErrorCameraNotFound")
+        static let captureErrorNoOutputDirectory = L10n.localisedString(key: "imageCaptureStep.captureErrorNoOutputDirectory")
+        static let captureErrorCannotWriteFile = L10n.localisedString(key: "imageCaptureStep.captureErrorCannotWriteFile")
+        static let photoLibraryNotAvailable = L10n.localisedString(key: "imageCaptureStep.photoLibraryNotAvailable")
     }
 }

--- a/MWCameraPlugin/MWCameraPlugin/MWCameraPlugin.swift
+++ b/MWCameraPlugin/MWCameraPlugin/MWCameraPlugin.swift
@@ -20,6 +20,7 @@ public enum MWCameraStepType: String, StepType, CaseIterable {
     case barcode = "io.mobileworkflow.barcodescanner"
     case videoCaptureModal = "io.mobileworkflow.VideoCaptureModal"
     case videoCapture = "io.mobileworkflow.VideoCapture"
+    case imageCapture = "io.mobileworkflow.ImageCapture"
     
     public var typeName: String {
         return self.rawValue
@@ -31,6 +32,7 @@ public enum MWCameraStepType: String, StepType, CaseIterable {
         case .barcode: return MWBarcodeStep.self
         case .videoCaptureModal: return MWVideoCaptureModalStep.self
         case .videoCapture: return MWVideoCaptureInViewStep.self
+        case .imageCapture: return MWImageCaptureStep.self
         }
     }
 }

--- a/MWCameraPlugin/MWCameraPlugin/ar.lproj/Localizable.strings
+++ b/MWCameraPlugin/MWCameraPlugin/ar.lproj/Localizable.strings
@@ -26,3 +26,15 @@
 "videoCaptureStep.cancelTitle" = "يلغي";
 "videoCaptureStep.nextButtonTitle" = "التالي";
 "videoCaptureStep.skipButtonTitle" = "تخطي";
+
+//ImageCaptureStep
+"imageCaptureStep.captureImage" = "التقاط صورة";
+"imageCaptureStep.recaptureImage" = "إعادة التقاط الصورة";
+"imageCaptureStep.nextButtonTitle" = "التالي";
+"imageCaptureStep.skipButtonTitle" = "تخطي";
+"imageCaptureStep.cameraUnavailable" = "الكاميرا غير متوفرة في العرض المقسم.";
+"imageCaptureStep.captureErrorNoPermissions" = "لإكمال هذه الخطوة، اسمح لهذا التطبيق بالوصول إلى الكاميرا في الإعدادات.";
+"imageCaptureStep.captureErrorCameraNotFound" = "لم يتم العثور على كاميرا.  لا يمكن إكمال هذه الخطوة.";
+"imageCaptureStep.captureErrorNoOutputDirectory" = "لم يتم تحديد دليل إخراج للصور الملتقطة.";
+"imageCaptureStep.captureErrorCannotWriteFile" = "لا يمكن حفظ الصورة الملتقطة.";
+"imageCaptureStep.photoLibraryNotAvailable" = "مكتبة الصور غير متوفرة";

--- a/MWCameraPlugin/MWCameraPlugin/en.lproj/Localizable.strings
+++ b/MWCameraPlugin/MWCameraPlugin/en.lproj/Localizable.strings
@@ -24,3 +24,15 @@
 "videoCaptureStep.cancelTitle" = "Cancel";
 "videoCaptureStep.nextButtonTitle" = "Next";
 "videoCaptureStep.skipButtonTitle" = "Skip";
+
+//ImageCaptureStep
+"imageCaptureStep.captureImage" = "Capture Image";
+"imageCaptureStep.recaptureImage" = "Recapture Image";
+"imageCaptureStep.nextButtonTitle" = "Next";
+"imageCaptureStep.skipButtonTitle" = "Skip";
+"imageCaptureStep.cameraUnavailable" = "Camera not available in split screen.";
+"imageCaptureStep.captureErrorNoPermissions" = "In order to complete this step, allow this app access to the camera in Settings.";
+"imageCaptureStep.captureErrorCameraNotFound" = "No camera found.  This step cannot be completed.";
+"imageCaptureStep.captureErrorNoOutputDirectory" = "No output directory was specified for captured images.";
+"imageCaptureStep.captureErrorCannotWriteFile" = "The captured image could not be saved.";
+"imageCaptureStep.photoLibraryNotAvailable" = "Photo Library is not available";


### PR DESCRIPTION
[MW-1960]

I have created V3 for the Camera plugin and copied the Image Capture step there. I have refactored research kit Image Capture step and added it to the camera plugin. 

So currently the core Image Capture step will use Research Kit Image Capture Step and the Camera Plugin Image Capture step will use the refactored Image Capture step in Swift and without Research Kit dependencies.

**Steps to test:**

* Create an app
* Install Camera Plugin
* Add a Camera Plugin Image Capture step
* Add a Core Image Capture step

**Expected result:**

The new Camera Plugin Image capture step should behave the same as the original Image Capture step with the bugs fixed.

Next step will be to remove Image Capture Step from the Core, but maybe we should have a quick chat about best approach for the migration.

[MW-1960]: https://futureworkshops.atlassian.net/browse/MW-1960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ