### PR TITLE
Restored ValueProvider and JSONRepresentable conformance to QRCodeResult

### DIFF
--- a/MWCameraPlugin.podspec
+++ b/MWCameraPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWCameraPlugin'
-    s.version               = '0.2.0'
+    s.version               = '0.2.1'
     s.summary               = 'Camera plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Camera plugin for MobileWorkflow on iOS, containg camera capture related steps:

--- a/MWCameraPlugin/MWCameraPlugin/QR Code Step/QRCodeResult.swift
+++ b/MWCameraPlugin/MWCameraPlugin/QR Code Step/QRCodeResult.swift
@@ -23,3 +23,20 @@ final class QRCodeResult: StepResult, Codable {
         try container.encode(self.codeFound)
     }
 }
+
+extension QRCodeResult: ValueProvider {
+    func fetchValue(for path: String) -> Any? {
+        return self.codeFound
+    }
+    
+    func fetchProvider(for path: String) -> ValueProvider? {
+        return self.codeFound
+    }
+}
+
+extension QRCodeResult: JSONRepresentable {
+    var jsonContent: String? {
+        guard let data = try? JSONEncoder().encode(self) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+}


### PR DESCRIPTION
**Task**

https://3.basecamp.com/5245563/buckets/26145695/todos/4685522897

**Goal**

To ensure that QR results can be retrieved as session values and appear in JSON uploads.

**Implementation**

Copied the conformances from `BarcodeResult`, which was moved to another plugin and I guess must have previously been providing the conformance via a `typealias` or similar.