### PR TITLE
Animated transition for remotely loaded images

### DIFF
--- a/MWCameraPlugin.podspec
+++ b/MWCameraPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWCameraPlugin'
-    s.version               = '0.2.2'
+    s.version               = '0.2.3'
     s.summary               = 'Camera plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Camera plugin for MobileWorkflow on iOS, containg camera capture related steps:

--- a/MWCameraPlugin/MWCameraPlugin/Image Capture Step/MWImageCaptureViewController.swift
+++ b/MWCameraPlugin/MWCameraPlugin/Image Capture Step/MWImageCaptureViewController.swift
@@ -194,8 +194,8 @@ final class MWImageCaptureViewController: MWContentStepViewController, UINavigat
         
         guard let imageUrl = self.imageCaptureStep.imageURL, self.imageCaptureView.templateImage == nil else {return}
         
-        self.templateImageLoad = self.imageCaptureStep.services.imageLoadingService.asyncLoad(image: imageUrl, session: self.imageCaptureStep.session) { [weak self] in
-            self?.imageCaptureView.templateImage = $0
+        self.templateImageLoad = self.imageCaptureStep.services.imageLoadingService.load(image: imageUrl, session: self.imageCaptureStep.session) { [weak self] result in
+            self?.imageCaptureView.templateImage = result.image
             self?.templateImageLoad = nil
         }
         


### PR DESCRIPTION
### Task

[[iOS] [Android] Image loading states](https://3.basecamp.com/5245563/buckets/26145695/todos/4825281143/edit?replace=true)

### Summary

Adding animated transition to loaded image.

### Implementation

Updated to use `ImageLoadingService` `load(image:session:completion:)` and `UIImageView` `transition(to:animated:completion:)` to update the image. 
