### PR TITLE
[iOS] Add optional flag to image capture

### DIFF
--- a/MWCameraPlugin.podspec
+++ b/MWCameraPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWCameraPlugin'
-    s.version               = '0.3.0'
+    s.version               = '0.3.1'
     s.summary               = 'Camera plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Camera plugin for MobileWorkflow on iOS, containg camera capture related steps:

--- a/MWCameraPlugin/MWCameraPlugin/Image Capture Step/MWImageCaptureStep.swift
+++ b/MWCameraPlugin/MWCameraPlugin/Image Capture Step/MWImageCaptureStep.swift
@@ -25,6 +25,7 @@ final class MWImageCaptureStep: MWStep {
          devicePosition: String?,
          compressionQuality: CGFloat?,
          showGalleryOption: Bool?,
+         isOptional: Bool?,
          session: Session,
          services: StepServices,
          theme: Theme) {
@@ -34,7 +35,11 @@ final class MWImageCaptureStep: MWStep {
         self.showGalleryOption = showGalleryOption ?? false
         self.session = session
         self.services = services
-        super.init(identifier: identifier, theme: theme)
+        super.init(
+            identifier: identifier,
+            isOptional: isOptional ?? false,
+            theme: theme
+        )
     }
     
     required init(coder aDecoder: NSCoder) {
@@ -57,6 +62,7 @@ extension MWImageCaptureStep: BuildableStep {
                                   devicePosition: stepInfo.data.content["devicePosition"] as? String,
                                   compressionQuality: stepInfo.data.content["imageQuality"] as? CGFloat,
                                   showGalleryOption: stepInfo.data.content["showGalleryOption"] as? Bool,
+                                  isOptional: stepInfo.data.content["optional"] as? Bool,
                                   session: stepInfo.session,
                                   services: services,
                                   theme: stepInfo.context.theme)


### PR DESCRIPTION
### Task

[[iOS] Add optional flag to image capture](https://3.basecamp.com/5245563/buckets/26145695/todos/5055612422/edit?replace=true)

### Feature/Issue

There is now an 'optional' flag in the builder for image capture steps. When 'true', the step should show a 'Skip' button to bypass the step without capturing an image.

### Implementation

This functionality was already supported within the step, we just needed to parse and pass through the 'optional' flag.